### PR TITLE
feat: Added fargate scaling on services.

### DIFF
--- a/lib/ecs-containers/fnContainer.ts
+++ b/lib/ecs-containers/fnContainer.ts
@@ -63,6 +63,15 @@ export class FnContainer extends Construct {
       },
     });
 
+    const scalableTarget = fnService.autoScaleTaskCount({
+      minCapacity: 1,
+      maxCapacity: 10,
+    });
+
+    scalableTarget.scaleOnCpuUtilization("fn-scaling", {
+      targetUtilizationPercent: 75,
+    });
+
     fnService.connections.allowFrom(
       props.servicesSecurityGroup,
       ec2.Port.tcp(3000),

--- a/lib/ecs-containers/workerContainer.ts
+++ b/lib/ecs-containers/workerContainer.ts
@@ -60,6 +60,15 @@ export class WorkersContainer extends Construct {
       },
     });
 
+    const scalableTarget = workersService.autoScaleTaskCount({
+      minCapacity: 1,
+      maxCapacity: 5,
+    });
+
+    scalableTarget.scaleOnCpuUtilization("workers-scaling", {
+      targetUtilizationPercent: 75,
+    });
+
     workersService.node.addDependency(props.mongoConstruct);
   }
 }

--- a/lib/rds/rdsConstruct.ts
+++ b/lib/rds/rdsConstruct.ts
@@ -62,7 +62,7 @@ export class RdsConstruct extends Construct {
       engine,
       instanceType: ec2.InstanceType.of(
         ec2.InstanceClass.BURSTABLE3,
-        ec2.InstanceSize.MICRO
+        ec2.InstanceSize.SMALL
       ),
       securityGroups: [this.securityGroup],
       multiAz: false,

--- a/package.json
+++ b/package.json
@@ -5,11 +5,10 @@
     "infrastructure": "bin/infrastructure.js"
   },
   "scripts": {
-    "test": "jest",
-    "cdk": "cdk",
     "prepare": "cd lambda/events && npm run build && cd ../initDb && rm -rf node_modules && npm install",
     "deploy": "npm run prepare && cdk deploy",
-    "synth": "npm run prepare && cdk synth"
+    "synth": "npm run prepare && cdk synth",
+    "destroy": "cdk destroy"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
- Added feature to scale from 1-5 workers service tasks and 1-10 function service tasks on target cpu load of 75%. 
- Increased database to t3.small, for performance. This gives us ~200 connections vs less than 100 with micro. We can change if we cant get it to scale high enough to matter.